### PR TITLE
Refactor code to draw indicators table in overview page.

### DIFF
--- a/country_config/null_technical.json
+++ b/country_config/null_technical.json
@@ -175,7 +175,8 @@
         {
             "title": "Indicators",
             "html_class": "col-md-6",
-            "parentId": "OvIndicators",
+            "parentId": "tbody-sparkline",
+            "html_base": "<table id='table-sparkline' style='width:100%'><thead><tr><th>Indicator name</th><th>Cumulative</th><th>Indicator chart</th></tr></thead><tbody id='tbody-sparkline'></tbody></table>",
             "contents": [
                 {
                     "api": "/indicators/n,d,m/gen_1,tot_1,100/<loc_id>",


### PR DESCRIPTION
I have refactored code for the Overview page, so that nothing is hard coded. 

The most important change is the new "base_html" field in an overview box's configs.  This specifies base html to populate the box with before drawing up the contents.  By default the box is populated with a DIV based table. If you want anything different it needs to be specified in the configs.  Indicators has a table header and so needs some special base_html content.

***NOTE: this will need to be translated in madagascar, and will need to be copied across to all country configs showing indicators in the same manner.*** 

Making this small change means the rest of the indicator code can be significantly simplified.

Other important thing to note is that the JSON dictionary timeline returned by an API call maynot appear in order of time! JSON dictionaries do not necessarily preserve order, so I have added sort() functioanlity to the dictionary keys before extracting the timeline as an array of values. 