### PR TITLE
Fix travis

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -47,6 +47,9 @@
     "leaflet-omnivore": {
       "main": "leaflet-omnivore.js"
     },
+    "tableExport.jquery.plugin": {
+      "main": "tableExport.min.js"
+    },
     "mapbox.js": {
       "main": [
         "mapbox.css",

--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,7 @@
     "leaflet.markercluster": "~1.0.3",
     "leaflet.awesome-markers": "^2.0.2",
     "mapbox.js": "~3.0.1",
-    "tableExport.jquery.plugin": "~1.5.0",
+    "tableExport.jquery.plugin": "~1.9.6",
     "raven-js": "~3.12.0",
     "bootstrap-datepicker": "~1.7.0",
     "throbber.js": "~0.0.2"
@@ -64,6 +64,7 @@
     }
   },
   "resolutions": {
-    "tableExport.jquery.plugin": "~1.6.8"
+    "tableExport.jquery.plugin": "~1.6.8",
+    "jspdf": "1.1.239 || 1.3.2"
   }
 }

--- a/meerkat_frontend/src/files/pages/mh_diseases.html
+++ b/meerkat_frontend/src/files/pages/mh_diseases.html
@@ -14,26 +14,26 @@
     </div>
     <div id="epi-week-title" class="col-xs-12 col-sm-12 col-md-3 pull-right box ">
     </div>
-    
+
 </div>
 
 <div class="demographics toggled" id="wrapper">
-    
+
     <div id="sidebar-wrapper" >
 	<div id="location-selector" class="location-selector">
-            
+
 	</div>
     </div>
-    
+
     <div id="page-content-wrapper">
 	<div class="row">
 	    <div class="col-xs-12 less-padding-col">
 		<div class="chartBox box">
 		    <div class="chartBox__heading">
                         <p id="box_heading"></p>
-                        
+
 			<div class="box__type-selector pull-right">
-			    <a href="" onclick="exportTableToXLS('disease-table','mhds');return false;" class="csv">
+			    <a href="" onclick="exportTableToXLS('mh_disease-table','mhds');return false;" class="csv">
 			    </a>
 			</div>
 		    </div>
@@ -49,9 +49,9 @@
 		<div class="chartBox box">
 		    <div class="chartBox__heading">
                         <p id="box_heading_1"></p>
-                        
+
 			<div class="box__type-selector pull-right">
-			    <a href="" onclick="exportTableToXLS('disease-table','icd');return false;" class="csv">
+			    <a href="" onclick="exportTableToXLS('mh_disease-table-icd','icd');return false;" class="csv">
 			    </a>
 			</div>
 		    </div>
@@ -94,11 +94,11 @@ $("#epi-week-title").html( i18n.gettext("Week")+" "+get_epi_week() + " · " + ge
 
 /*//Every tab needs a draw charts function that is called when loading a new location.
 function drawCharts( locID ){
-     
+
      //Keep week abstracted out of the chart drawing process.
      //In case we want the use to eb able to select the weeks to view.
      var week = get_epi_week().toString();
-     
+
      categorySummation({ category: 'mhgap',
 	                 locID: locID,
 	                 week: week,

--- a/meerkat_frontend/src/js/technical/misc.js
+++ b/meerkat_frontend/src/js/technical/misc.js
@@ -587,7 +587,9 @@ function exportTableToXLS(tableID, filename) {
 
     //Return the percentage values to the HTML design ...
     chartPercentageList.each(
-        function(index, element){$(element).html(oldValueArray[index]);}
+        function(index, element){
+            $(element).html(oldValueArray[index]);
+        }
     );
 
     return false;

--- a/meerkat_frontend/src/js/technical/misc.js
+++ b/meerkat_frontend/src/js/technical/misc.js
@@ -570,13 +570,14 @@ function exportTableToCSV(tableID, filename, link) {
 function exportTableToXLS(tableID, filename) {
     //Get all the Percentage values that are inside the "table-percent" class ...
     var oldValueArray = [];
-    var chartPercentageList = document.getElementById(tableID).getElementsByClassName("table-percent");
+    var chartPercentageList = $('#'+tableID + ' .table-percent');
 
-    //Save the percentage values into array and remove it so we can generate Exele file without percentage ...
-    for (var i = 0; i <= chartPercentageList.length - 1; i++) {
-        oldValueArray.push(chartPercentageList[i].innerHTML);
-        chartPercentageList[i].innerHTML = "";
-    }
+    chartPercentageList.each(
+        function(index, element){
+            oldValueArray.push($(element).html());
+            $(element).html("");
+        }
+    );
 
     //Call the generate xls ...
     $('#' + tableID + ' table').tableExport({
@@ -585,9 +586,9 @@ function exportTableToXLS(tableID, filename) {
     });
 
     //Return the percentage values to the HTML design ...
-    for (var j = 0; j <= chartPercentageList.length - 1; j++) {
-        chartPercentageList[j].innerHTML = oldValueArray[j];
-    }
+    chartPercentageList.each(
+        function(index, element){$(element).html(oldValueArray[index]);}
+    );
 
     return false;
 }

--- a/meerkat_frontend/templates/includes/js.html
+++ b/meerkat_frontend/templates/includes/js.html
@@ -24,7 +24,7 @@
 <script src="{{ url_for('static', filename='js/bootstrap-datepicker.js') }}"></script>
 <script src="{{ url_for('static', filename='js/bootstrap-table.js') }}"></script>
 <script src="{{ url_for('static', filename='js/bootstrap-table-en-US.js') }}"></script>
-<script src="{{ url_for('static', filename='js/tableExport.js') }}"></script>
+<script src="{{ url_for('static', filename='js/tableExport.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/featherlight.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/js.cookie.js') }}"></script>
 <script src="{{ url_for('static', filename='js/leaflet.awesome-markers.js') }}"></script>

--- a/meerkat_frontend/templates/includes/js.html
+++ b/meerkat_frontend/templates/includes/js.html
@@ -24,7 +24,7 @@
 <script src="{{ url_for('static', filename='js/bootstrap-datepicker.js') }}"></script>
 <script src="{{ url_for('static', filename='js/bootstrap-table.js') }}"></script>
 <script src="{{ url_for('static', filename='js/bootstrap-table-en-US.js') }}"></script>
-<script src="{{ url_for('static', filename='js/tableExport.min.js') }}"></script>
+<script src="{{ url_for('static', filename='js/tableExport.js') }}"></script>
 <script src="{{ url_for('static', filename='js/featherlight.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/js.cookie.js') }}"></script>
 <script src="{{ url_for('static', filename='js/leaflet.awesome-markers.js') }}"></script>


### PR DESCRIPTION
Travis builds are breaking because of an obselete 2nd level dependancy `filesaver.js`.  Here I update `tableExport.jquery.plugin` bower dependancy which nown depends upon `file-saver` instead of the broken package `filesaver.js`. For some reason this dependancy still has some problems in that within itself it has a dependancy conflict that we need to resolve in our bower file. But a simple resolution setting it to be the most recent version seems to fix problems.  The second commit also fixes up problems with the XLS export function in our code that uses the dependancy. 