### PR TITLE
Sys-admin message flashes to the frontend.

### DIFF
--- a/meerkat_frontend/__init__.py
+++ b/meerkat_frontend/__init__.py
@@ -4,7 +4,8 @@ meerkat_frontend.py
 This module runs as the Flask app from app.py and mounts component Flask apps
 for different services such as the API and Reports.
 """
-from .app import app, babel, sentry, auth
+from .app import app, babel, sentry
+from .authentication import auth
 from slugify import slugify
 from flask import render_template, request, Blueprint
 from flask import current_app, abort, flash, g, redirect
@@ -165,6 +166,7 @@ def error_test(error):
            error (int): The error code for the requested error.
     """
     abort(error)
+
 
 @app.errorhandler(400)
 @app.errorhandler(404)

--- a/meerkat_frontend/app.py
+++ b/meerkat_frontend/app.py
@@ -4,12 +4,10 @@ meerkat_app.py
 Sets up the Root Flask app for the Meerkat Frontend, so it can be imported
 at the begining of files, without complicated import chains.
 """
-
-from flask import Flask, g
+from flask import Flask
 from flask.ext.babel import Babel
 from raven.contrib.flask import Sentry
 from werkzeug.contrib.fixers import ProxyFix
-from meerkat_libs.auth_client import Authorise as libs_auth
 import jinja2
 import os
 import json
@@ -61,52 +59,6 @@ class FlaskG(app.app_ctx_globals_class):
     def __init__(self):
         self.allowed_location = 1
         self.config = copy.deepcopy(display_configs)
+        self.language = app.config['DEFAULT_LANGUAGE']
 
 app.app_ctx_globals_class = FlaskG
-
-
-# Extend the Authorise object so that we can restrict access to location
-class Authorise(libs_auth):
-    """
-    Extension of the meerkat_libs auth_client Authorise class. We override one
-    of its functions so that it works smoothly in meerkat_auth.
-    """
-    # Override the check_auth method
-    def check_auth(self, access, countries, logic='OR'):
-        # First check that the user has required access levels.
-        libs_auth.check_auth(self, access, countries, logic)
-
-        # Continue by checking if the user has restrcited access to location
-        # Cycle through each location restriction level
-        # If the restriction level is in the users access, set the allowed loc
-        allowed_location = 9999
-
-        for level, loc in app.config.get('LOCATION_AUTH', {}).items():
-            access = Authorise.check_access(
-                [level],
-                [app.config['COUNTRY']],
-                g.payload['acc']
-            )
-            if access and loc < allowed_location:  # Prioritise small loc id
-                allowed_location = loc
-
-        # If no restriction set, then default to the whole country.
-        if allowed_location is 9999:
-            allowed_location = 1
-
-        # Set the allowed location root
-        g.allowed_location = allowed_location
-
-        # Apply config overrides for specific access levels.
-        if app.config.get('CONFIG_OVERRIDES', {}):
-            # Order override priority according to order of users access.
-            for level in reversed(g.payload['acc'][app.config['COUNTRY']]):
-                if level in app.config.get('CONFIG_OVERRIDES', {}):
-                    for k, v in app.config['COMPONENT_CONFIGS'].items():
-                        g.config[k] = {
-                            **app.config[k],
-                            **app.config['CONFIG_OVERRIDES'][level]
-                        }
-
-# The extended authorise object used across this flask app to restrict access
-auth = Authorise()

--- a/meerkat_frontend/authentication.py
+++ b/meerkat_frontend/authentication.py
@@ -1,0 +1,54 @@
+from flask import g
+from meerkat_libs.auth_client import Authorise as libs_auth
+from .app import app
+from .messages import messages
+
+
+# Extend the Authorise object so that we can restrict access to location
+class Authorise(libs_auth):
+    """
+    Extension of the meerkat_libs auth_client Authorise class. We override one
+    of its functions so that it works smoothly in meerkat_auth.
+    """
+    # Override the check_auth method
+    def check_auth(self, access, countries, logic='OR'):
+        # First check that the user has required access levels.
+        libs_auth.check_auth(self, access, countries, logic)
+
+        # Continue by checking if the user has restrcited access to location
+        # Cycle through each location restriction level
+        # If the restriction level is in the users access, set the allowed loc
+        allowed_location = 9999
+
+        for level, loc in app.config.get('LOCATION_AUTH', {}).items():
+            access = Authorise.check_access(
+                [level],
+                [app.config['COUNTRY']],
+                g.payload['acc']
+            )
+            if access and loc < allowed_location:  # Prioritise small loc id
+                allowed_location = loc
+
+        # If no restriction set, then default to the whole country.
+        if allowed_location is 9999:
+            allowed_location = 1
+
+        # Set the allowed location root
+        g.allowed_location = allowed_location
+
+        # Apply config overrides for specific access levels.
+        if app.config.get('CONFIG_OVERRIDES', {}):
+            # Order override priority according to order of users access.
+            for level in reversed(g.payload['acc'][app.config['COUNTRY']]):
+                if level in app.config.get('CONFIG_OVERRIDES', {}):
+                    for k, v in app.config['COMPONENT_CONFIGS'].items():
+                        g.config[k] = {
+                            **app.config[k],
+                            **app.config['CONFIG_OVERRIDES'][level]
+                        }
+
+        # Flashing messages depends upon users access, so flash after auth.
+        messages.flash()
+
+# The extended authorise object used across this flask app to restrict access
+auth = Authorise()

--- a/meerkat_frontend/config.py
+++ b/meerkat_frontend/config.py
@@ -13,7 +13,12 @@ class Config(object):
     LIVE_URL = os.environ.get("MEERKAT_LIVE_URL", "http://127.0.0.1/")
     INTERNAL_API_ROOT = os.environ.get("INTERNAL_API_ROOT", '')
     EXTERNAL_API_ROOT = '/api'
-
+    DYNAMODB_URL = os.environ.get(
+        'DYNAMODB_URL',
+        'https://dynamodb.eu-west-1.amazonaws.com'
+    )
+    FLASH_MESSAGES_TABLE = 'frontend_messages'
+    FLASH_RELOAD_INTERVAL = 36000  # In seconds, so every 10 minutes
     HERMES_ROOT = os.environ.get("HERMES_API_ROOT", "")
     HERMES_API_KEY = os.environ.get('HERMES_API_KEY', 'test-hermes')
     MAILING_KEY = os.environ.get('MAILING_KEY', 'test-mailing')

--- a/meerkat_frontend/messages.py
+++ b/meerkat_frontend/messages.py
@@ -46,7 +46,7 @@ class FlashMessages():
                 region_name='eu-west-1'
             )
         except Exception:
-            app.logger.error(
+            app.logger.warning(
                 'Failed to connect to flash messages DB.',
                 exc_info=True
             )
@@ -82,7 +82,7 @@ class FlashMessages():
                 }
             ).get("Items", [])
         except Exception:
-            app.logger.error(
+            app.logger.warning(
                 'Failed to get flash messages.',
                 exc_info=True
             )
@@ -176,5 +176,6 @@ class FlashMessages():
         """Condition: Only publish on pages with URLs that match the regex."""
         return bool(re.compile(regex).match(request.path))
 
-# There is only really need for one instansiation of this object.
+
+# This design is based upon the "singleton" pattern - only one instansiation.
 messages = FlashMessages()

--- a/meerkat_frontend/messages.py
+++ b/meerkat_frontend/messages.py
@@ -61,14 +61,21 @@ class FlashMessages():
         dynamodb endpoint url specified in the config.
         """
         country = app.config["SHARED_CONFIG"]["auth_country"]
-        self.messages = FlashMessages.DB.query(
-            KeyConditions={
-                'country': {
-                    'AttributeValueList': [country],
-                    'ComparisonOperator': 'EQ'
+        try:
+            self.messages = FlashMessages.DB.query(
+                KeyConditions={
+                    'country': {
+                        'AttributeValueList': [country],
+                        'ComparisonOperator': 'EQ'
+                    }
                 }
-            }
-        ).get("Items", [])
+            ).get("Items", [])
+        except Exception:
+            app.logger.error(
+                'Failed to get flash messages.',
+                exc_info=True
+            )
+            self.messages = []
         self.last_update = datetime.now()
         app.logger.info("Updated " + repr(self))
 

--- a/meerkat_frontend/messages.py
+++ b/meerkat_frontend/messages.py
@@ -1,0 +1,161 @@
+from datetime import datetime
+from .app import app
+from meerkat_libs.auth_client import Authorise
+from flask import flash, g, request
+from dateutil import parser
+import boto3
+import re
+
+
+class FlashMessages():
+    """
+    A FlashMessages object shows messages using the Flask "flash" system. The
+    messages are loaded from the FLASH_MESSAGES_TABLE specified in the config
+    that should be available from the DYNAMODB_URL endpoint specified in the
+    config. These messages are reloaded when the config's FLASH_RELOAD_INTERVAL
+    passes, or when the developer specifies a truthy "flash_reload" GET arg in
+    the URL. The following conditions can be placed upon a message:
+
+        published: Message is hidden if set to 'false' or 'no'.
+        start_date: A timestamp from which to start showing the message.
+        end_date: A timestamp up to which the message should be shown.
+        access: An access level required to see the message.
+        page: A URL regex determining which pages the message is shown upon.
+
+    A condition is specified by adding a 'column' in the dynamodb table.  All
+    conditions must be met for the message to be displayed. An example message
+    to insert into the dynamodb table might look like this:
+        ```
+            {
+                'country': 'demo',
+                'id': 'example-message',
+                'en': 'This is the english translation',
+                'fr': 'This is the french translation',
+                'published': 'False',  # Hidden for now
+                'page': '(.*)download(.*)',  # Only show on download page
+                'start_date': '2018/2/1'  # Start to show from 1st Feb 2018
+            }
+        ```
+    """
+
+    DB = boto3.resource(
+        'dynamodb',
+        endpoint_url=app.config['DYNAMODB_URL'],
+        region_name='eu-west-1'
+    ).Table(app.config['FLASH_MESSAGES_TABLE'])
+
+    def __init__(self):
+        self.get_messages()
+
+    def __repr__(self):
+        """Creates a detailed string representation of this object."""
+        return "FlashMessages Object ({})\n{}".format(
+            self.last_update,
+            self.messages
+        )
+
+    def get_messages(self):
+        """
+        Get all messages for the website's country from the dynamodb table.
+        There should be a table "frontend_messages" accessible from the
+        dynamodb endpoint url specified in the config.
+        """
+        country = app.config["SHARED_CONFIG"]["auth_country"]
+        self.messages = FlashMessages.DB.query(
+            KeyConditions={
+                'country': {
+                    'AttributeValueList': [country],
+                    'ComparisonOperator': 'EQ'
+                }
+            }
+        ).get("Items", [])
+        self.last_update = datetime.now()
+        app.logger.info("Updated " + repr(self))
+
+    def flash(self, force_reload=False):
+        """
+        Show the messages specified by the sys admin.  This function should be
+        called before each important request in the frontend.  The timing of
+        the call is important, as this function depends upon the auth process.
+        It has to happen before rendering the template, but after processing
+        the auth.
+
+        A GET arg can be specified in the URL "flash_reload", which will reload
+        the flash messages if it equates to True.  This way the developer
+        does not need to wait for the interval to pass to check their message
+        is good.
+
+        Arguments:
+            force_reload(bool): Force the reload of the flash messages.  Can
+                also wait for the FLASH_RELOAD_INTERVAL to pass, or include
+                "?flash_reload=true" GET arg in the URL.
+        """
+        # Get messages if requested to, or if the interval has passed.
+        # i.e. Don't need to get messages from dynamoDB during every request.
+        interval = (datetime.now()-self.last_update).seconds
+        flash_reload = interval > app.config['FLASH_RELOAD_INTERVAL']
+        flash_reload = flash_reload or request.args.get('flash_reload')
+        if flash_reload or force_reload:
+            self.get_messages()
+        # Show the messages, which should be labelled by lang code.
+        for message in self.messages:
+            content = message.get(
+                g.language,
+                message.get(app.config['DEFAULT_LANGUAGE'])
+            )
+            if content and self.meets_conditions(message):
+                flash(content, message.get('category', 'info'))
+
+    def meets_conditions(self, message):
+        """
+        Check if a message should be shown to the user.  Does this by checking
+        each parameter of the message and seeing if there is a corresponding
+        condition function defined in this instance of FlashMessages.  All
+        valid conditions must be met for the message to show.
+
+        Arguments:
+            message(dict): The message under consideration, which is a record
+                loaded from the dynamodb table.
+
+        Returns:
+            bool stating whether all valid conditions have been met or not.
+        """
+        results = []
+        for key, value in message.items():
+            try:
+                condition = getattr(FlashMessages, "_{}_condition".format(key))
+                results += [condition(value)]
+            except AttributeError:
+                pass
+        return all(results)
+
+    def _published_condition(published):
+        """Condition: Is the message published?"""
+        return published not in ["false", "False", "no", "No"]
+
+    def _start_date_condition(date):
+        """Condition: Publish message from a time stamp"""
+        return datetime.now() >= parser.parse(date)
+
+    def _end_date_condition(date):
+        """Condition: Publish message until a timestamp"""
+        return datetime.now() < parser.parse(date)
+
+    def _access_condition(levels):
+        """Condition: Only publish for users with specified access."""
+        levels = [levels] if type(levels) is not list else levels
+        if hasattr(g, 'payload'):
+            return Authorise.check_access(
+                levels,
+                [app.config["SHARED_CONFIG"]['auth_country']],
+                g.payload['acc'],
+                logic='AND'
+            )
+        return False
+
+    def _page_condition(regex):
+        """Condition: Only publish on pages with URLs that match the regex."""
+        return bool(re.compile(regex).match(request.path))
+
+# There is only really need for one instansiation of this object.
+messages = FlashMessages()

--- a/meerkat_frontend/src/sass/_messaging.scss
+++ b/meerkat_frontend/src/sass/_messaging.scss
@@ -101,43 +101,55 @@ ul.flashes{
 
 	margin-top: 10px;
 	list-style:none;
+    position: absolute;
+    width:100%;
+    z-index: 10;
 
-	li{
+}
 
-		text-align: center;
+ul.flashes li{
 
-		.frame{
-			display: inline-block;
-			border: $blue solid 2px;
-			border-radius: 5px;
-			background: #FFF;
-			position: relative;
-			margin: 10px 0px 0px;
-		}
+	text-align: center;
 
-		.text{
-			padding: 10px 20px 10px 60px;
-			font-size: 16px;
-		}
+	.frame{
+		display: inline-block;
+		border: $blue solid 2px;
+		border-radius: 5px;
+		background: #FFF;
+		position: relative;
+		margin: 10px 0px 0px;
+	}
 
+	.text{
+		padding: 10px 20px 10px 60px;
+		font-size: 16px;
+	}
+
+	span{
+		color: #FFF;
+		background: #0090CA;
+		padding: 0px 12px;
+		font-size: 20px;
+		vertical-align: middle;
+		position: absolute;
+		left: 0px;
+		top: 0px;
+		line-height: 45px;
+		height: 100%;
+	}
+
+	div.warning{
+		border: 2px solid $highlight;
 		span{
-			color: #FFF;
-			background: #0090CA;
-			padding: 0px 12px;
-			font-size: 20px;
-			vertical-align: middle;
-			position: absolute;
-			left: 0px;
-			top: 0px;
-			line-height: 45px;
-			height: 100%;
-		}
-
-		div.error{
-			border: 2px solid $highlight;
-			span{
-				background: $highlight;
-			}
+			background: $highlight;
 		}
 	}
+
+    div.error{
+		border: 2px solid darkred;
+		span{
+			background: darkred;
+		}
+	}
+
 }

--- a/meerkat_frontend/src/sass/_messaging.scss
+++ b/meerkat_frontend/src/sass/_messaging.scss
@@ -97,7 +97,7 @@ form.subscribe{
 	}
 }
 
-ul.flashes{
+.homepage ul.flashes{
 
 	margin-top: 10px;
 	list-style:none;
@@ -109,6 +109,8 @@ ul.flashes{
 
 ul.flashes li{
 
+    margin-top: 10px;
+	list-style:none;
 	text-align: center;
 
 	.frame{

--- a/meerkat_frontend/views/homepage.py
+++ b/meerkat_frontend/views/homepage.py
@@ -8,6 +8,7 @@ from flask import request, make_response, redirect, flash, abort
 from flask.ext.babel import gettext
 from meerkat_frontend import app, auth
 from meerkat_frontend import common as c
+from meerkat_frontend.messages import messages
 from meerkat_libs import hermes
 import requests
 import logging
@@ -16,6 +17,15 @@ import datetime
 # Register the homepage blueprint.
 homepage = Blueprint('homepage', __name__, url_prefix='/<language>')
 homepage_route = app.config.get("HOMEPAGE_ROUTE", "")
+
+
+@homepage.before_request
+def before():
+    """
+    Run statements before the homepage requests are processed.
+    """
+    # Messages to be flashed to the user from the system admins
+    messages.flash()
 
 
 @homepage.route('/' + homepage_route)


### PR DESCRIPTION
Introduces the ability to flash messages in the frontend by editing a dynamodb table.  Will allow us to put up temporary notices of maitenance, downtime, errors etc...

Messages can be restricted to certain pages, certain times and certain access levels. They can be info, warning or error level (colouring changes). They are automatically updatd every 10 minutes, or when someone includes a specific get arg in a request to the site. 

https://github.com/meerkat-code/meerkat_issues/issues/251