### PR TITLE
Issue 274

### DIFF
--- a/meerkat_frontend/src/js/technical/overview.js
+++ b/meerkat_frontend/src/js/technical/overview.js
@@ -192,29 +192,37 @@ function prep_row_draw_Last3(contentsObj, parentId, locID) {
 
             //I need only 3 ...
             for (var i = 0; i <= 2; i++) {
-                arrFinal.push(arrAlerts[i].val);
-                arrFinalDate.push(arrAlerts[i].date);
+                if(arrAlerts[i]){
+                    arrFinal.push(arrAlerts[i].val);
+                    arrFinalDate.push(arrAlerts[i].date);
+                }
             }
 
             var alertCounter = 0;
-            $.each(arrFinal, function(index, value) {
-                var detailApiUrl = "/variable/" + value;
+            if(arrAlerts.length){
+                $.each(arrFinal, function(index, value) {
+                    var detailApiUrl = "/variable/" + value;
+                    //Call Other API to get the details for each value in the arrFInal Array ...
+                    $.getJSON(api_root + detailApiUrl, function(detailData) {
 
-                //Call Other API to get the details for each value in the arrFInal Array ...
-                $.getJSON(api_root + detailApiUrl, function(detailData) {
+                        $('#' + elementID).append(
+                            "<div><span class='col-xs-7 col-xs-offset-1'>" +
+                            i18n.gettext(detailData.name) +
+                            "</span><span class='col-xs-4'>" +
+                            ovDateFormate(arrFinalDate[alertCounter]) +
+                            "</label></div>");
 
-                    $('#' + elementID).append(
-                        "<div><span class='col-xs-7 col-xs-offset-1'>" +
-                        i18n.gettext(detailData.name) +
-                        "</span><span class='col-xs-4'>" +
-                        ovDateFormate(arrFinalDate[alertCounter]) +
-                        "</label></div>");
+                        alertCounter = alertCounter + 1;
 
-                    alertCounter = alertCounter + 1;
+                    });
 
                 });
-
-            });
+            }else{
+                $('#' + elementID).append(
+                    "<div><span class='col-xs-7 col-xs-offset-1'>" +
+                    i18n.gettext("No data") + "</span></div>"
+                );
+            }
 
         });
 


### PR DESCRIPTION
Fixing Sentry raised issue:

https://github.com/meerkat-code/meerkat_issues/issues/274

Error raised when trying to view the overview page for a location that has never raised any alerts. The following fix in this PR should sort that.  NOTE that I have introduced the string "No data" in this PR on line 223.  It needs to be translated!

I also propose that we change the labels in the overview page as follows:
>Top 3 most common causes of morbidity -> Most common causes of morbitiy
>Top 3 most common causes of mortality -> Most common causes of mortality
>Last 3 alerts -> Latest alerts

This is because the number of items may be actually be anything between 0 and 3 depending on the data available. This will require PR in country config repo that simply changes the "label" fields here:
https://github.com/meerkat-code/meerkat_mad/blob/development/frontend/mad_technical.json#L96-L110

We would also need to add the corresponding translation strings for these three labels. I have asked Toavina for all required translation strings in Madagascar slack channel. @mixmixmix I'm away next week, maybe you could create the changes in meerkat_mad?