### PR TITLE
Properly cleaning up of old leaflet html for diseases page.

### DIFF
--- a/meerkat_frontend/src/files/pages/disease.html
+++ b/meerkat_frontend/src/files/pages/disease.html
@@ -252,9 +252,6 @@
     }
 
     function reDrawMap(locID) {
-        if (map) {
-            map.remove();
-        }
         var map_type = $('#type-selector select').val();
         if (map_type == "incidence_clinic") {
             drawIncidenceMap(name, disease, "disease-map");

--- a/meerkat_frontend/src/js/technical/mapManager.js
+++ b/meerkat_frontend/src/js/technical/mapManager.js
@@ -320,6 +320,8 @@ function drawIncidenceMap(name, varID, containerID, location, start_date, end_da
 function clearOldMap() {
     if (typeof map !== 'undefined') {
         map.remove();
+    }
+    if ($('#total-map').length === 0) {
         $('#mapbox').html("<div id='total-map' class='the-map'></div>");
     }
 }


### PR DESCRIPTION
A small improvement for clearing out old leaflet html elements. All the cleanup is now done in mapManager.js for all pages.