### PR TITLE
Freeze timeline col

### DIFF
--- a/meerkat_frontend/src/js/explore/explore.js
+++ b/meerkat_frontend/src/js/explore/explore.js
@@ -393,7 +393,7 @@ function createTimeline(id, cat, options, title) {
             $("#timeline-table td:nth-child(2)").css('width', (1+titleWidth)+'px');
             $("#timeline-table").css('margin-left', (36+titleWidth)+'px');
         }
-        setWidth()
+        setWidth();
         $('#timeline-table').on('all.bs.table', setWidth);
 
 

--- a/meerkat_frontend/src/js/explore/explore.js
+++ b/meerkat_frontend/src/js/explore/explore.js
@@ -6,14 +6,14 @@
     :param string catx:
         The category to tabulated across the columns
     :param string caty:
-        The category to be tabulated down the rows. 
+        The category to be tabulated down the rows.
     :param object options:
-        The options object detailing how the table should be put together. 
+        The options object detailing how the table should be put together.
         Can have the following properties:
-        
+
         * **start_date** (string) - The start date by which to filter data (in ISO format).
         * **end_date** (string) - The end date by which to filter data (in ISO format).
-        * **location** (number) - The location ID by which to filter the data. 
+        * **location** (number) - The location ID by which to filter the data.
         * **strip** (boolean) - Strip empty rows from the table.
         * **colour** (boolean) - Colour the cells with a shade of the highlight colour.
           according to the proportion of the range that the value represents.
@@ -212,7 +212,7 @@ function createColourCell(maxMin) {
 
 function max_min(data) {
     // Returns max and min of all numbers in table
-    // Used to correctly colour the table. 
+    // Used to correctly colour the table.
     var list = [];
     for (var r = 1; r < data.length; r++) {
         var row = data[r];
@@ -238,8 +238,8 @@ function timelineLink(id, name, axis) {
 
 /**:createTimeline(id, cat, options)
 
-    Tabulates the number of cases satisfying the given variable in each week, against 
-    the number of cases satisfying each variable in the given category. 
+    Tabulates the number of cases satisfying the given variable in each week, against
+    the number of cases satisfying each variable in the given category.
 
     :param string id:
         The given variable ID.
@@ -251,7 +251,7 @@ function timelineLink(id, name, axis) {
 
         * **start_date** (string) - The start date by which to filter data (in ISO format).
         * **end_date** (string) - The end date by which to filter data (in ISO format).
-        * **location** (number) - The location ID by which to filter the data. 
+        * **location** (number) - The location ID by which to filter the data.
         * **strip** (boolean) - Strip empty rows from the table.
         * **colour** (boolean) - Colour the cells with a shade of the highlight colour.
           according to the proportion of the range that the value represents.
@@ -385,6 +385,9 @@ function createTimeline(id, cat, options, title) {
             data: data,
             clickToSelect: true
         });
+        titleWidth = $("#timeline-table th:nth-child(2)").width();
+        $("#timeline-table td:nth-child(2)").css('width', (1+titleWidth)+'px');
+        $("#timeline-table").css('margin-left', (36+titleWidth)+'px');
     });
 }
 

--- a/meerkat_frontend/src/js/explore/explore.js
+++ b/meerkat_frontend/src/js/explore/explore.js
@@ -385,9 +385,18 @@ function createTimeline(id, cat, options, title) {
             data: data,
             clickToSelect: true
         });
-        titleWidth = $("#timeline-table th:nth-child(2)").width();
-        $("#timeline-table td:nth-child(2)").css('width', (1+titleWidth)+'px');
-        $("#timeline-table").css('margin-left', (36+titleWidth)+'px');
+
+        // Set the width of 2nd column to content of header
+        //Needed because we freeze the column
+        function setWidth(){
+            titleWidth = $("#timeline-table th:nth-child(2)").width();
+            $("#timeline-table td:nth-child(2)").css('width', (1+titleWidth)+'px');
+            $("#timeline-table").css('margin-left', (36+titleWidth)+'px');
+        }
+        setWidth()
+        $('#timeline-table').on('all.bs.table', setWidth);
+
+
     });
 }
 

--- a/meerkat_frontend/src/sass/_explore.scss
+++ b/meerkat_frontend/src/sass/_explore.scss
@@ -1,122 +1,121 @@
-
-
 .exploreChart{
-	
-	.row{
-		width: 100%;
-		display: flex;
-		margin-top: 5px;
-	}
 
-	.cornerBox{
-		width: 55px;
-		height: 45px;
-		margin-right: 5px;
-		text-align: center;
-		
-		span{
-			transform: rotate(-45deg);
-			margin-left: 5px;
-			margin-top: 3px;
-			font-size: 20px;
-			cursor: pointer;
-		}
+    .row{
+        width: 100%;
+        display: flex;
+        margin-top: 5px;
+    }
 
-	}
+    .cornerBox{
+        width: 55px;
+        height: 45px;
+        margin-right: 5px;
+        text-align: center;
 
-	.xaxis{
-		width: calc(100% - 45px);
-		height: 45px;
+        span{
+            transform: rotate(-45deg);
+            margin-left: 5px;
+            margin-top: 3px;
+            font-size: 20px;
+            cursor: pointer;
+        }
 
-		.axis-selector{
-			margin-left: 80px;
-			width: 300px;
-			float: left;
-		}
-	
-	}
+    }
 
-	.options{
-		float: right;
-		font-size: 20px;
-		margin-right: 10px;
+    .xaxis{
+        width: calc(100% - 45px);
+        height: 45px;
 
-		span{
-			cursor: pointer;
-			width: 40px;
-		}
-	}
+        .axis-selector{
+            margin-left: 80px;
+            width: 300px;
+            float: left;
+        }
 
-	.yaxis,
-	.xaxis,
-	.cornerBox,
-	.chartBox{
-		float: left;
-	}
-	
-	.yaxis{
- 		width: 55px;
-		margin-right: 5px;
-		position:relative;
-		text-align: center;
+    }
+
+    .options{
+        float: right;
+        font-size: 20px;
+        margin-right: 10px;
+
+        span{
+            cursor: pointer;
+            width: 40px;
+        }
+    }
+
+    .yaxis,
+    .xaxis,
+    .cornerBox,
+    .chartBox{
+        float: left;
+    }
+
+    .yaxis{
+         width: 55px;
+        margin-right: 5px;
+        position:relative;
+        text-align: center;
         min-height: 320px;
-	}	
+    }
 
-	.chartBox{
-		width: calc(100% - 60px);
-	}
+    .chartBox{
+        width: calc(100% - 60px);
+    }
 
     .chart-row{
         margin-top:5px;
     }
 
-	.yaxis .axis-selector{
+    .yaxis .axis-selector{
 
-		width: 300px;
-		position: absolute;
-		top: 150px;
-		left: -125px;
-		display: inline-block;
+        width: 300px;
+        position: absolute;
+        top: 150px;
+        left: -125px;
+        display: inline-block;
 
-		select{
-			-ms-transform: rotate(-90deg); /* IE 9 */
-			-webkit-transform: rotate(-90deg); /* Chrome, Safari, Opera */
-			transform: rotate(-90deg);
-		}
-	}
+        select{
+            -ms-transform: rotate(-90deg); /* IE 9 */
+            -webkit-transform: rotate(-90deg); /* Chrome, Safari, Opera */
+            transform: rotate(-90deg);
+        }
+    }
 
-	.timeline-toolbar{
-		width: 100%;
-	}
+    .timeline-toolbar{
+        width: 100%;
+        margin-top: 30px;
+    }
 
-	.timeline{
-		width: 100%;
-	    padding: 0px;
-	}
+    .timeline{
+        width: 100%;
+        padding: 0px;
+    }
 
-	.table, th{
-		text-align: center;
-		margin: 0px;
-	}
+    .table, th{
+        text-align: center;
+        margin: 0px;
+    }
 
-	.table th,
-	.table .header{
-		background: #f9f9f9;
-		font-weight: bold;
-	}
+    .table th,
+    .table .header{
+        background: #f9f9f9;
+        font-weight: bold;
+    }
 
-	.table .header{
-		border-right: 1px solid #ddd;
-		text-align: left;
-	}
+    .table .header{
+        border-right: 1px solid #ddd;
+        text-align: left;
+    }
 }
 
 .explore .bootstrap-table .fixed-table-toolbar{
-		 	display: none;
-		 }
+             display: none;
+         }
 
 #cross-table, #timeline-table{
-	margin-top: -2px !important;
+    margin-top: -2px !important;
 }
 
 #cross-wrapper, #timeline-wrapper{
@@ -124,21 +123,40 @@
     text-align: center;
 
     .spinner{
-	    display: inline-block;
+        display: inline-block;
         margin-top: 49px;
         margin-bottom: 49px;
         height: 220px;
     }
+}
 
+#timeline-table{
+    th:first-child, td:first-child{
+        background: #f9f9f9;
+        left: 0px;
+        position: absolute;
+        width: 36px;
+        height: 41px;
+        border-bottom: 1px solid #ddd;
+    }
+    th:nth-child(2), td:nth-child(2){
+        background: #f9f9f9;
+        left: 36px;
+        position: absolute;
+        height: 41px;
+        border-bottom: 1px solid #ddd;
+    }
+    th{
+        top: 0px;
+    }
 }
 
 #timeline{
     display: none;
 }
 
-.explore .total-row, 
+.explore .total-row,
 .explore .total-col{
     background: #f9f9f9;
     border: 1px solid #ddd
 }
-

--- a/meerkat_frontend/src/sass/_explore.scss
+++ b/meerkat_frontend/src/sass/_explore.scss
@@ -136,18 +136,19 @@
         left: 0px;
         position: absolute;
         width: 36px;
-        height: 41px;
         border-bottom: 1px solid #ddd;
     }
     th:nth-child(2), td:nth-child(2){
         background: #f9f9f9;
         left: 36px;
         position: absolute;
-        height: 41px;
         border-bottom: 1px solid #ddd;
+    }
+    tr:last-child td:first-child, tr:last-child td:nth-child(2){
     }
     th{
         top: 0px;
+        height:41px;
     }
 }
 

--- a/meerkat_frontend/templates/explore/index.html
+++ b/meerkat_frontend/templates/explore/index.html
@@ -101,7 +101,6 @@
                         </div>
                     </div>
                     <div id="timeline">
-                      <div class='breaker'></div>
                         <div class="row">
                             <div class="box timeline-toolbar" >
                                 <div class="options">

--- a/meerkat_frontend/templates/explore/index.html
+++ b/meerkat_frontend/templates/explore/index.html
@@ -101,6 +101,7 @@
                         </div>
                     </div>
                     <div id="timeline">
+                      <div class='breaker'></div>
                         <div class="row">
                             <div class="box timeline-toolbar" >
                                 <div class="options">


### PR DESCRIPTION
This PR freezes the first column of the timeline table in explore.  This has been requested by Madagascar. 

It does this by setting the first two column's position properties to "absolute" and then mannually setting the width and the height of the cells. The width of the cells are set to the width of the header cell's content. This has to be done mannually on every reload of the table in Javascript. 